### PR TITLE
Issue 92 - Implemented tooltip for career interest + others

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -8941,6 +8941,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
     "mongo-object": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/mongo-object/-/mongo-object-0.1.4.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -14,6 +14,7 @@
     "jquery": "^3.5.0",
     "jsonfile": "^6.0.1",
     "lodash": "^4.17.15",
+    "moment": "^2.29.1",
     "natural": "^2.1.5",
     "node-sass": "^4.14.1",
     "popper.js": "^1.16.1",

--- a/src/src/InternshipFilters.jsx
+++ b/src/src/InternshipFilters.jsx
@@ -209,7 +209,6 @@ class InternshipsFilters {
 
   /* Returns a list based on search query */
   filterBySearch(data, searchQuery) {
-    // console.log(searchQuery);
     if (searchQuery.length === 0) {
       return data;
     }
@@ -236,12 +235,6 @@ class InternshipsFilters {
     }
     return arrLocations;
 
-    // // Add all the internships where remote == true and those who have remote in state
-    // if (input === 'Remote') {
-    //   const byState = _.filter(data, ['location.state', input]);
-    //   const remote = _.filter(data, ['remote', true]);
-    //   return _.concat(byState, remote);
-    // }
   }
 
   isRemote(data, value) {

--- a/src/src/InternshipListing.jsx
+++ b/src/src/InternshipListing.jsx
@@ -13,7 +13,7 @@ function InternshipListing() {
 
   const [data, setData] = useState(getInternshipData);
   const [paginatedData, setPaginatedData] = useState(getInternshipData.slice(0, 40));
-  const [location, setLocation] = useState('any');
+  const [location, setLocation] = useState([]);
   const [company, setCompany] = useState('any');
   const [sort, setSort] = useState('date');
   const [search, setSearch] = useState('');

--- a/src/src/InternshipListing.jsx
+++ b/src/src/InternshipListing.jsx
@@ -21,14 +21,16 @@ function InternshipListing() {
   const [remote, setRemote] = useState(false);
   const [page, setPage] = useState(1);
   const [height, setHeight] = useState(0);
+  const [career, setCareer] = useState([]);
   const ref = useRef(null);
 
   /* Passes data up from SearchInternshipFeature. SetPaginatedData allows data to be rendered
   * for infinite scroll. */
-  function handleChildClick(passedData, locationVal, companyVal, sortVal, searchQueryVal, skillsVal, isRemote) {
+  function handleChildClick(passedData, locationVal, companyVal, sortVal, searchQueryVal, skillsVal, isRemote, careerVal) {
     setData(passedData);
     setLocation(locationVal);
     setCompany(companyVal);
+    setCareer(careerVal);
     setSort(sortVal);
     setSearch(searchQueryVal);
     setSkills(skillsVal);
@@ -79,7 +81,7 @@ function InternshipListing() {
           <Grid.Row style={{ maxWidth: '80%', margin: 'auto' }}>
             <SearchInternshipFeature onChildClick={handleChildClick} passedData={data}
                                      companyVal={company} locationVal={location} sortVal={sort}
-                                     searchQuery={search} skillsVal={skills} isRemote={remote}/>
+                                     searchQuery={search} skillsVal={skills} isRemote={remote} careerVal={career}/>
             <div onScroll={handleScroll()} ref={ref}>
               <Card.Group doubling centered stackable>
                 {_.map(paginatedData, (internship, index) => <InternshipListingCard

--- a/src/src/InternshipListingCard.jsx
+++ b/src/src/InternshipListingCard.jsx
@@ -11,6 +11,7 @@ import {
   Radio, Item
 } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
+import moment from "moment";
 import React from 'react';
 
 function isRemote(remote) {
@@ -56,7 +57,8 @@ function hasSkill(skill) {
 }
 
 function formatDate(stringDate) {
-  const date = new Date(stringDate).toDateString();
+  const date = moment(stringDate).fromNow();
+  // const date = new Date(stringDate).toDateString();
   if (date !== 'Invalid Date') {
     return date;
   }
@@ -157,7 +159,7 @@ function InternshipListingCard(props) {
                 </Grid.Column>
                 <Grid.Column floated={'left'}>
                   <Icon className='calendar alternate'/>
-                  <span>Date Posted: {formatDate(props.internship.posted)}</span>
+                  <span>Last Updated: {formatDate(props.internship.posted)}</span>
                 </Grid.Column>
               </Grid.Row>
 

--- a/src/src/NavBar.jsx
+++ b/src/src/NavBar.jsx
@@ -17,12 +17,13 @@ class NavBar extends React.Component {
                 <Image src={'images/logo.png'} size={'small'}/>
               </a>
             </Menu.Item>
-            <Menu.Item>
-              <Link to='/all-internships' style={linkStyle}>All Internships</Link>
-            </Menu.Item>
-            <Menu.Item>
-              <Link to='/internaloha' style={linkStyle}>Recommended Internships</Link>
-            </Menu.Item>
+            {/*<Menu.Item>*/}
+            {/*  <Link to='/all-internships' style={linkStyle}>All Internships</Link>*/}
+            {/*</Menu.Item>*/}
+            {/*<Menu.Item>*/}
+            {/*  <Link to='/internaloha' style={linkStyle}>Recommended Internships</Link>*/}
+            {/*</Menu.Item>*/}
+
             {/*<Menu.Item>*/}
             {/*  <Link to="/statistics" style={linkStyle}>Statistics</Link>*/}
             {/*</Menu.Item>*/}

--- a/src/src/RecommendationScript.js
+++ b/src/src/RecommendationScript.js
@@ -1,7 +1,19 @@
 import natural from 'natural';
+import React from 'react';
 import _ from 'lodash';
 import career_interest_to_skill from './career_interest_to_skill';
-
+import {
+  Button,
+  Card,
+  Grid,
+  Icon,
+  Label,
+  Modal,
+  Header,
+  Popup,
+  Form,
+  Radio, Item, Dropdown
+} from 'semantic-ui-react';
 function test(data) {
   const TfIdf = natural.TfIdf;
   const tfidf = new TfIdf();
@@ -22,7 +34,7 @@ function test(data) {
   tfidf.tfidfs('javascript full-stack css hmtl ', function (i, measure) {
     //  console.log('document #' + i + ' is ' + measure);
     if (measure > 6) {
-      console.log('document #' + i + ' is ' + measure);
+      console.log(`document #${i} is ${measure}`);
       tfidfData.push(data[i]);
     }
   });
@@ -40,10 +52,20 @@ function dropdownCareerInterest() {
 
   const info = [];
   for (let i = 0; i < career_interest_to_skill.length; i++) {
+    const skills = career_interest_to_skill[i].skills.join(', ');
     info.push({
       key: career_interest_to_skill[i].career,
       text: career_interest_to_skill[i].career,
       value: career_interest_to_skill[i].career,
+      content: (
+          <Popup content={`Associated Skills: ${skills}`}
+                 trigger={<Dropdown.Item>
+            {career_interest_to_skill[i].career}</Dropdown.Item>}
+                 style={{ marginLeft: '12%' }}
+                 position={'right center'}
+                 basic inverted
+          />
+      ),
     });
   }
   return info;
@@ -111,7 +133,7 @@ function recommendation(tags, careers, data, location) {
 
   const sorted = _.orderBy(skills, ['recommendation'], ['desc']);
 
-  //console.log(sorted);
+  // console.log(sorted);
 
 // for (let i = 0; i < data.length; i++) {
 //   // if any of the tags exist in data set, push it to skills and go to next
@@ -152,7 +174,7 @@ function isRemoteFunc(data, value) {
   if (value === false) {
     return data;
   }
-  console.log(_.filter(data, ['remote', true]))
+  console.log(_.filter(data, ['remote', true]));
   return _.filter(data, ['remote', true]);
 }
 

--- a/src/src/SearchInternshipFeature.jsx
+++ b/src/src/SearchInternshipFeature.jsx
@@ -79,10 +79,6 @@ function SearchInternshipFeature({ onChildClick, passedData, locationVal, compan
     setFilters();
   };
 
-  const getCompany = (event, { value }) => {
-    companyChange = value;
-    setFilters();
-  };
 
   const getSort = (event, { value }) => {
     sortChange = value;
@@ -180,17 +176,6 @@ function SearchInternshipFeature({ onChildClick, passedData, locationVal, compan
               <Checkbox style={{ paddingTop: '1rem' }} label='Remote'
                         onClick={getRemote}/>
             </Grid.Column>
-
-            {/*<div style={{ paddingTop: '2rem' }}>*/}
-            {/*  <Header>Company</Header>*/}
-            {/*  <Dropdown*/}
-            {/*      placeholder='Select a company'*/}
-            {/*      fluid selection options={internships.dropdownCompany(passedData)}*/}
-            {/*      defaultValue={company[0].value}*/}
-            {/*      onChange={getCompany}*/}
-            {/*      search*/}
-            {/*  />*/}
-            {/*</div>*/}
             <Grid.Column>
               <Form onSubmit={handleSubmit}>
                 <Form.Field icon='home'
@@ -203,17 +188,7 @@ function SearchInternshipFeature({ onChildClick, passedData, locationVal, compan
                 />
               </Form>
             </Grid.Column>
-            {/*<Grid.Row>*/}
-            {/*  <div style={{ paddingBottom: '2rem', paddingRight: '0.5rem' }} align={'center'}>*/}
-            {/*    <Header as={'h4'}>Key</Header>*/}
-            {/*    <Label circular style={has}>*/}
-            {/*      Has skill*/}
-            {/*    </Label>*/}
-            {/*    <Label circular style={notHave}>*/}
-            {/*      Missing skill*/}
-            {/*    </Label>*/}
-            {/*  </div>*/}
-            {/*</Grid.Row>*/}
+
           </Grid.Row>
           <Grid.Row>
             <Grid.Column>

--- a/src/src/SearchInternshipFeature.jsx
+++ b/src/src/SearchInternshipFeature.jsx
@@ -1,332 +1,281 @@
 import React from 'react';
 import {
-  Segment,
-  Header,
-  Dropdown,
-  Label,
-  Input,
-  Form,
-  Checkbox,
-  Popup,
-  Search,
-  Menu,
-  Image, Container, Grid,
+    Segment,
+    Header,
+    Dropdown,
+    Label,
+    Input,
+    Form,
+    Checkbox,
+    Popup,
+    Grid,
+    Button
 } from 'semantic-ui-react';
-import _ from 'lodash';
 import PropTypes from 'prop-types';
 import InternshipsFilters from './InternshipFilters';
-import { Link } from 'react-router-dom';
+import {dropdownCareerInterest, recommendation} from "./RecommendationScript";
 
-function SearchInternshipFeature({ onChildClick, passedData, locationVal, companyVal, sortVal, searchQuery, skillsVal, isRemote }) {
+function SearchInternshipFeature({
+                                     onChildClick,
+                                     passedData,
+                                     locationVal,
+                                     companyVal,
+                                     sortVal,
+                                     searchQuery,
+                                     skillsVal,
+                                     isRemote,
+                                     careerVal,
+                                 }) {
 
-  const internships = new InternshipsFilters();
-  const data = internships.mergeData();
+    const internships = new InternshipsFilters();
+    const data = internships.mergeData();
 
-  let locationChange = locationVal;
-  let companyChange = companyVal;
-  let sortChange = sortVal;
-  let searchQueryChange = searchQuery;
-  let skillChange = skillsVal;
-  let remoteCheck = isRemote;
+    let locationChange = locationVal;
+    let companyChange = companyVal;
+    let sortChange = sortVal;
+    let searchQueryChange = searchQuery;
+    let skillChange = skillsVal;
+    let remoteCheck = isRemote;
+    let careerChange = careerVal;
 
-  const sortBy = [
-    { key: 'date', text: 'date', value: 'date' },
-    { key: 'internship', text: 'internship', value: 'internship' },
-    { key: 'company', text: 'company', value: 'company' },
-  ];
+    const sortBy = [
+        {key: 'date', text: 'date', value: 'date'},
+        {key: 'internship', text: 'internship', value: 'internship'},
+        {key: 'company', text: 'company', value: 'company'},
+    ];
 
-  const location = internships.dropdownLocation(data);
-  const company = internships.dropdownCompany(data);
 
-  const setFilters = () => {
-    const remoteFilter = internships.isRemote(data, remoteCheck);
-    const searchFiltered = internships.filterBySearch(remoteFilter, searchQueryChange);
-    const skillsFiltered = internships.filterBySkills(searchFiltered, skillChange);
-    const locationFiltered = internships.filterByLocation(skillsFiltered, locationChange);
-    const companyFiltered = internships.filterByCompany(locationFiltered, companyChange);
-    const sorted = internships.sortedBy(companyFiltered, sortChange);
-    onChildClick(sorted, locationChange, companyChange, sortChange, searchQueryChange, skillChange, remoteCheck);
-    window.scrollTo({
-      top: 30,
-      left: 100,
-      behavior: 'smooth',
-    });
-  };
+    const setFilters = () => {
 
-  const handleSearchChange = (event) => {
-    searchQueryChange = event.target.value;
-  };
+        let recommendedData = [];
 
-  const handleCompanyChange = (event) => {
-    companyChange = event.target.value;
-  };
+        const remoteFilter = internships.isRemote(data, remoteCheck);
+        const searchFiltered = internships.filterBySearch(remoteFilter, searchQueryChange);
+        // const skillsFiltered = internships.filterBySkills(searchFiltered, skillChange);
+        // const locationFiltered = internships.filterByLocation(skillsFiltered, locationChange);
+        const companyFiltered = internships.filterByCompany(searchFiltered, companyChange);
+        const sorted = internships.sortedBy(companyFiltered, sortChange);
 
-  const getRemote = () => {
-    if (remoteCheck) {
-      remoteCheck = false;
-    } else {
-      remoteCheck = true;
+        recommendedData = recommendation(skillChange, careerChange, sorted, locationChange);
+
+        onChildClick(recommendedData, locationChange, companyChange, sortChange, searchQueryChange, skillChange, remoteCheck, careerChange);
+        window.scrollTo({
+            top: 30,
+            left: 100,
+            behavior: 'smooth',
+        });
+    };
+
+    const handleSearchChange = (event) => {
+        searchQueryChange = event.target.value;
+    };
+
+    const handleCompanyChange = (event) => {
+        companyChange = event.target.value;
+    };
+
+    const getRemote = () => {
+        if (remoteCheck) {
+            remoteCheck = false;
+        } else {
+            remoteCheck = true;
+        }
+        setFilters();
+    };
+
+    const handleSubmit = () => {
+        setFilters();
+    };
+
+    const getLocation = (event, {value}) => {
+        locationChange = value;
+        setFilters();
+    };
+
+    const getSort = (event, {value}) => {
+        sortChange = value;
+        setFilters();
+    };
+
+    const getSkills = (event, {value}) => {
+        skillChange = value;
+        setFilters();
+    };
+
+    const getCareerInterest = (event, {value}) => {
+        careerChange = value;
+        setFilters();
+    };
+
+    const has = {
+        margin: '0.2rem',
+        backgroundColor: '#5680E9',
+        color: 'white',
+    };
+    const notHave = {
+        margin: '0.2rem',
+        backgroundColor: 'rgb(244, 244, 244)',
+        color: '#8f8f8f',
+    };
+
+    const careerSkills = (skill) => {
+        return (
+            <Label circular key={skill}>
+                {skill}
+            </Label>
+        );
     }
-    setFilters();
-  };
 
-  const handleSubmit = () => {
-    setFilters();
-  };
+    return (
+        <Segment style={{width: '100%', borderRadius: '10px', marginTop: '3rem'}}>
+            <Grid columns={'equal'}>
+                <Grid.Row>
+                    <Grid.Column>
+                        <p>
+                            <p>
+                                Sort by {' '}
+                                <Dropdown
+                                    inline
+                                    header='Sort by...'
+                                    options={sortBy}
+                                    defaultValue={sortBy[0].value}
+                                    onChange={getSort}
+                                />
+                            </p>
+                        </p>
+                    </Grid.Column>
+                    <Grid.Column>
+                        <Form onSubmit={handleSubmit}>
+                            <Popup
+                                trigger={
+                                    <Form>
+                                        <Form.Field icon='search'
+                                                    iconPosition='left'
+                                                    placeholder='Search ...'
+                                                    onChange={handleSearchChange}
+                                                    fluid
+                                                    control={Input}
+                                                    label={{children: 'Search'}}
+                                        />
+                                    </Form>
+                                }
+                                content='Press enter to search by internship titles!'
+                                on={'focus'}
+                            />
 
-  const getLocation = (event, { value }) => {
-    locationChange = value;
-    setFilters();
-  };
+                        </Form>
+                    </Grid.Column>
+                    <Grid.Column>
+                        <Form onSubmit={handleSubmit}>
+                            <Form.Dropdown
+                                fluid multiple selection clearable
+                                control={Dropdown}
+                                options={dropdownCareerInterest()}
+                                label={{ children: 'Career Interest' }}
+                                placeholder='Career Interest'
+                                search
+                                onChange={getCareerInterest}>
+                            </Form.Dropdown>
+                            {/*<Form.Field*/}
+                            {/*    fluid multiple selection clearable*/}
+                            {/*    control={Dropdown}*/}
+                            {/*    options={dropdownCareerInterest()}*/}
+                            {/*    label={{children: 'Career Interest'}}*/}
+                            {/*    placeholder='Career Interest'*/}
+                            {/*    search*/}
+                            {/*    onChange={getCareerInterest}*/}
+                            {/*/>*/}
+                        </Form>
+                    </Grid.Column>
+                    <Grid.Column>
+                        <Form>
+                            <Form.Field
+                                label={{children: 'Skills'}}
+                                placeholder='Skills'
+                                search
+                                fluid multiple selection clearable
+                                control={Dropdown}
+                                options={ internships.dropdownSkills(data)}
+                                onChange={getSkills}
+                                style={{ flexGrow: 0 }}
 
+                            />
+                        </Form>
 
-  const getSort = (event, { value }) => {
-    sortChange = value;
-    setFilters();
-  };
+                    </Grid.Column>
+                    <Grid.Column>
+                        <Form>
+                            <Form.Field placeholder='Location'
+                                        label={{children: 'Location'}}
+                                        onChange={getLocation}
+                                        fluid multiple selection clearable
+                                        options={internships.dropdownLocation(data)}
+                                        control={Dropdown}
+                                        style={{flexGrow: 0}}
+                            />
+                        </Form>
+                        <Checkbox style={{paddingTop: '1rem'}} label='Remote'
+                                  onClick={getRemote}/>
+                    </Grid.Column>
+                    <Grid.Column>
+                        <Form onSubmit={handleSubmit}>
+                            <Form.Field icon='home'
+                                        label={{children: 'Company'}}
+                                        control={Input}
+                                        iconPosition='left'
+                                        placeholder='Company'
+                                        onChange={handleCompanyChange}
+                                        fluid
+                            />
+                        </Form>
+                    </Grid.Column>
 
-  const getSkills = (event, { value }) => {
-    skillChange = value;
-    setFilters();
-  };
+                </Grid.Row>
+                <Grid.Row>
+                    <Grid.Column>
+                        <Header style={{paddingBottom: '0', marginTop: '0rem'}}>
+                            Total results found: {internships.total(passedData)}
+                        </Header>
+                    </Grid.Column>
+                    <Grid.Column textAlign={'right'}>
+                        <Grid.Row>
+                            <div style={{paddingBottom: '0', paddingRight: '0.5rem'}}>
+                                <Header style={{
+                                    paddingBottom: '0', margin: '0 0 0 0', paddingRight: '0.5rem',
+                                    paddingTop: '0.3rem', lineHeight: '10px',
+                                    display: 'inline-block'
+                                }} as={'h4'}>
+                                    Key:
+                                </Header>
+                                <Label circular style={has}>
+                                    Has skill
+                                </Label>
+                                <Label circular style={notHave}>
+                                    Missing skill
+                                </Label>
+                            </div>
+                        </Grid.Row>
 
-  const sticky = {
-    position: '-webkit-sticky',
-    position: 'sticky',
-    top: '6.5rem',
-  };
+                    </Grid.Column>
+                </Grid.Row>
 
-  const has = {
-    margin: '0.2rem',
-    backgroundColor: '#5680E9',
-    color: 'white',
-  };
-  const notHave = {
-    margin: '0.2rem',
-    backgroundColor: 'rgb(244, 244, 244)',
-    color: '#8f8f8f',
-  };
+            </Grid>
 
-  return (
-      <Segment style={{ width: '100%', borderRadius: '10px', marginTop: '3rem' }}>
-        <Grid columns={'equal'}>
-          <Grid.Row>
-            <Grid.Column>
-              <p>
-                <p>
-                  Sort by {' '}
-                  <Dropdown
-                      inline
-                      header='Sort by...'
-                      options={sortBy}
-                      defaultValue={sortBy[0].value}
-                      onChange={getSort}
-                  />
-                </p>
-              </p>
-            </Grid.Column>
-            <Grid.Column>
-              <Form onSubmit={handleSubmit}>
-                <Popup
-                    trigger={
-                      <Form>
-                        <Form.Field icon='search'
-                                    iconPosition='left'
-                                    placeholder='Search ...'
-                                    onChange={handleSearchChange}
-                                    fluid
-                                    control={Input}
-                                    label={{ children: 'Search' }}
-                        />
-                      </Form>
-                    }
-                    content='Press enter to search by internship titles!'
-                    on={'focus'}
-                />
+        </Segment>
 
-              </Form>
-            </Grid.Column>
-            <Grid.Column>
-              <Form>
-                <Form.Field
-                    label={{ children: 'Skills' }}
-                    placeholder='Skills'
-                    search
-                    fluid multiple selection clearable
-                    control={Dropdown}
-                    options={internships.dropdownSkills(data)}
-                    onChange={getSkills}
-                    style={{ flexGrow: 0 }}
-
-                />
-              </Form>
-
-            </Grid.Column>
-            <Grid.Column>
-              <Form>
-                <Form.Field placeholder='Location'
-                            label={{ children: 'Location' }}
-                            onChange={getLocation}
-                            fluid multiple selection clearable
-                            options={internships.dropdownLocation(data)}
-                            control={Dropdown}
-                            style={{ flexGrow: 0 }}
-                />
-              </Form>
-              <Checkbox style={{ paddingTop: '1rem' }} label='Remote'
-                        onClick={getRemote}/>
-            </Grid.Column>
-            <Grid.Column>
-              <Form onSubmit={handleSubmit}>
-                <Form.Field icon='home'
-                            label={{ children: 'Company' }}
-                            control={Input}
-                            iconPosition='left'
-                            placeholder='Company'
-                            onChange={handleCompanyChange}
-                            fluid
-                />
-              </Form>
-            </Grid.Column>
-
-          </Grid.Row>
-          <Grid.Row>
-            <Grid.Column>
-              <Header style={{ paddingBottom: '0', marginTop: '0rem' }}>
-                Total results found: {internships.total(passedData)}
-              </Header>
-            </Grid.Column>
-            <Grid.Column textAlign={'right'}>
-              <Grid.Row>
-                <div style={{ paddingBottom: '0', paddingRight: '0.5rem' }}>
-                  <Header style={{
-                    paddingBottom: '0', margin: '0 0 0 0', paddingRight: '0.5rem',
-                    paddingTop: '0.3rem', lineHeight: '10px',
-                    display: 'inline-block'
-                  }} as={'h4'}>
-                    Key:
-                  </Header>
-                  <Label circular style={has}>
-                    Has skill
-                  </Label>
-                  <Label circular style={notHave}>
-                    Missing skill
-                  </Label>
-                </div>
-              </Grid.Row>
-
-            </Grid.Column>
-          </Grid.Row>
-
-        </Grid>
-
-      </Segment>
-
-      // <Segment style={sticky}>
-      //   <div style={{ paddingTop: '2rem' }}>
-      //     <Header>
-      //       <Header.Content>
-      //         Total results found: {internships.total(passedData)}
-      //       </Header.Content>
-      //     </Header>
-      //   </div>
-      //   <div style={{ paddingTop: '2rem' }}>
-      //     <Header>
-      //       <Header.Content>
-      //         Sort by {' '}
-      //         <Dropdown
-      //             inline
-      //             header='Sort by...'
-      //             options={sortBy}
-      //             defaultValue={sortBy[0].value}
-      //             onChange={getSort}
-      //         />
-      //       </Header.Content>
-      //     </Header>
-      //   </div>
-      //   <div style={{ paddingTop: '2rem' }}>
-      //     <Form onSubmit={handleSubmit}>
-      //       <Popup
-      //           trigger={<Input icon='search'
-      //                           iconPosition='left'
-      //                           placeholder='Search ...'
-      //                           onChange={handleSearchChange}
-      //                           fluid
-      //           />}
-      //           content='Press enter to search!'
-      //           on={'focus'}
-      //       />
-      //
-      //     </Form>
-      //     <div style={{ paddingTop: '2rem' }}>
-      //       <Header>Skills</Header>
-      //       <Dropdown
-      //           placeholder='Skills'
-      //           fluid
-      //           multiple
-      //           search
-      //           selection
-      //           options={internships.dropdownSkills()}
-      //           onChange={getSkills}
-      //       />
-      //     </div>
-      //   </div>
-      //   <div style={{ paddingTop: '2rem' }}>
-      //     <Header>Location</Header>
-      //     <Dropdown placeholder='Location'
-      //               onChange={getLocation}
-      //               defaultValue={location[0].value}
-      //               fluid selection options={internships.dropdownLocation(passedData)}
-      //               search
-      //     />
-      //     <Checkbox style={{ paddingTop: '1rem' }} label='Remote'
-      //               onClick={getRemote}/>
-      //   </div>
-      //
-      //   {/*<div style={{ paddingTop: '2rem' }}>*/}
-      //   {/*  <Header>Company</Header>*/}
-      //   {/*  <Dropdown*/}
-      //   {/*      placeholder='Select a company'*/}
-      //   {/*      fluid selection options={internships.dropdownCompany(passedData)}*/}
-      //   {/*      defaultValue={company[0].value}*/}
-      //   {/*      onChange={getCompany}*/}
-      //   {/*      search*/}
-      //   {/*  />*/}
-      //   {/*</div>*/}
-      //   <div style={{ paddingTop: '2rem' }}>
-      //     <Header>Company</Header>
-      //
-      //     <Form onSubmit={handleSubmit}>
-      //       <Input icon='home'
-      //              iconPosition='left'
-      //              placeholder='Enter a company'
-      //              onChange={handleCompanyChange}
-      //              fluid
-      //       />
-      //     </Form>
-      //   </div>
-      //   <div style={{ paddingTop: '2rem', paddingBottom: '2rem' }} align={'center'}>
-      //     <Header>Key</Header>
-      //     <Label circular style={has}>
-      //       Have skill
-      //     </Label>
-      //     <Label circular style={notHave}>
-      //       Missing skill
-      //     </Label>
-      //   </div>
-      // </Segment>
-  );
+    );
 }
 
 SearchInternshipFeature.propTypes = {
-  onChildClick: PropTypes.func.isRequired,
-  passedData: PropTypes.array.isRequired,
-  locationVal: PropTypes.string.isRequired,
-  companyVal: PropTypes.string.isRequired,
-  sortVal: PropTypes.string.isRequired,
-  searchQuery: PropTypes.string.isRequired,
-  skillsVal: PropTypes.array.isRequired,
-  isRemote: PropTypes.bool.isRequired,
+    onChildClick: PropTypes.func.isRequired,
+    passedData: PropTypes.array.isRequired,
+    locationVal: PropTypes.string.isRequired,
+    companyVal: PropTypes.string.isRequired,
+    sortVal: PropTypes.string.isRequired,
+    searchQuery: PropTypes.string.isRequired,
+    skillsVal: PropTypes.array.isRequired,
+    isRemote: PropTypes.bool.isRequired,
+    careerVal: PropTypes.array.isRequired,
 };
 
 export default SearchInternshipFeature;

--- a/src/src/career_interest_to_skill.json
+++ b/src/src/career_interest_to_skill.json
@@ -7,7 +7,8 @@
       "css",
       "html",
       "database",
-      "api"
+      "api",
+      "sql"
     ]
   },
   {

--- a/src/src/career_interest_to_skill.json
+++ b/src/src/career_interest_to_skill.json
@@ -36,5 +36,43 @@
       "database",
       "data science"
     ]
+  },
+  {
+    "career": "Software Engineering",
+    "skills": [
+      "javascript",
+      "react",
+      "css",
+      "html",
+      "database",
+      "api",
+      "sql"
+    ]
+  },
+  {
+    "career": "Systems Analyst",
+    "skills": [
+      "javascript",
+      "c and c++",
+      "database",
+      "api",
+      "sql"
+    ]
+  },
+  {
+    "career": "Security Engineering",
+    "skills": [
+      "cybersecurity",
+      "c and c++",
+      "database"
+    ]
+  },
+  {
+    "career": "Computer Network Architect",
+    "skills": [
+      "networking",
+      "c and c++",
+      "database"
+    ]
   }
 ]

--- a/src/src/index.js
+++ b/src/src/index.js
@@ -20,7 +20,7 @@ const App = () => (
       <NavBar/>
       <Switch>
         {/*<Route exact path={'/'} component={Landing}/>*/}
-        <Route exact path={'/internaloha'} component={RecommendedInternships}/>
+        <Route exact path={'/internaloha'} component={InternshipListing}/>
         <Route exact path={'/all-internships'} component={InternshipListing}/>
         <Route exact path={'/statistics'} component={Statistics}/>
         <Route exact path={'/profile'} component={Profile}/>


### PR DESCRIPTION
Fixed/Implemented:

- [x] What is the purpose of the "Career Goals" form controller? It is not evident from the UI.  Also, unlike locations and interests, there are no numbers next to it indicating how many internships are available for it.

- [x] Put Career Goals before Skills.

- [x] After selecting a Career Goal, indicate which skills were implicitly selected.

- [x] Remove all items from navbar. For the pilot study, there is just a single page that users should see.

- [x] The landing page that users should see is: https://internaloha.github.io/all-internships. But that is now the landing page, so no need "all-internships" in the URL.
- [ ] 
- [ ] Add more career goals.

- [x] Add "Last Updated" to each listing, using moment.js to indicate how old (i.e. "Yesterday", "last Monday", etc.
