### PR TITLE
Issue 150

### DIFF
--- a/scraper/scrapers/acm.js
+++ b/scraper/scrapers/acm.js
@@ -62,7 +62,7 @@ export async function main(headless) {
     Logger.error(err.message);
     await browser.close();
   }
-  Logger.error(`Finished scraper acm at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  Logger.error(`Elapsed time for acm: ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
 }
 
 export default main;

--- a/scraper/scrapers/aexpress.js
+++ b/scraper/scrapers/aexpress.js
@@ -66,7 +66,7 @@ async function main(headless) {
     Logger.debug(err.message);
     await browser.close();
   }
-  Logger.error(`Finished scraper aexpress at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  Logger.error(`Elapsed time for aexpress: ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
 }
 
 export default main;

--- a/scraper/scrapers/angellist.js
+++ b/scraper/scrapers/angellist.js
@@ -30,6 +30,7 @@ async function startBrowser() {
 }
 
 async function main(url) {
+  const startTime = new Date();
   log.error('Starting scraper angellist at', moment().format('LT'));
   const { browser, page } = await startBrowser();
   await page.setViewport({ width: 1366, height: 768 });
@@ -99,17 +100,17 @@ async function main(url) {
           log.warn(err);
         }
       });
+  log.error(`Elapsed time for angellist: ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
   await browser.close();
 }
 
 async function goTo() {
-  const startTime = new Date();
+
   try {
     await main('https://angel.co/login');
   } catch (err) {
     log.warn('Our Error: ', err.message);
   }
-  log.error(`Finished scraper angellist at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
   // process.exit(1);
 }
 export default goTo;

--- a/scraper/scrapers/apple.js
+++ b/scraper/scrapers/apple.js
@@ -92,7 +92,7 @@ async function main(headless) {
     await browser.close();
     Logger.error(err.message);
   }
-  Logger.error(`Finished scraper apple at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  Logger.error(`Elapsed time for apple: ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
 }
 
 export default main;

--- a/scraper/scrapers/cisco.js
+++ b/scraper/scrapers/cisco.js
@@ -68,7 +68,7 @@ export async function main(headless) {
     Logger.error(err.message);
     await browser.close();
   }
-  Logger.error(`Finished scraper cisco at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  Logger.error(`Elapsed time for Cisco: ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
 }
 
 export default main;

--- a/scraper/scrapers/glassdoor.js
+++ b/scraper/scrapers/glassdoor.js
@@ -141,7 +141,7 @@ async function main() {
     Logger.warn('Our Error:', err4.message);
     await browser.close();
   }
-  Logger.error(`Finished scraper glassdoor at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  Logger.error(`Elapsed time for glassdoor: ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
 }
 
 export default main;

--- a/scraper/scrapers/hawaiislack.js
+++ b/scraper/scrapers/hawaiislack.js
@@ -14,6 +14,7 @@ async function main(headless) {
   let browser;
   let page;
   const startTime = new Date();
+  const data = [];
   try {
     Logger.error('Starting scraper hawaiislack at', moment().format('LT'));
     [browser, page] = await startBrowser(headless);
@@ -27,7 +28,6 @@ async function main(headless) {
         document.querySelectorAll('ul[class="job_listings"] > li > a'),
         a => `${a.getAttribute('href')}`,
     ));
-    const data = [];
     // goes to each page
     // const expiredData = [];
     for (let i = 0; i < elements.length; i++) {
@@ -83,6 +83,6 @@ async function main(headless) {
     Logger.warn('Our Error:', err.message);
     await browser.close();
   }
-  Logger.error(`Finished scraper hawaiislack at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  Logger.error(`Elapsed time for hawaiislack: ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
 }
 export default main;

--- a/scraper/scrapers/iHireTechnology.js
+++ b/scraper/scrapers/iHireTechnology.js
@@ -152,7 +152,7 @@ async function main() {
     log.warn('Something went wrong', err.message);
     await browser.close();
   }
-  log.error(`Finished scraper ihiretechnology at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  log.error(`Elapsed time for ihiretechnology: ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
 }
 
 export default main;

--- a/scraper/scrapers/idealist.js
+++ b/scraper/scrapers/idealist.js
@@ -108,6 +108,7 @@ async function main(headless) {
   let browser;
   let page;
   const startTime = new Date();
+  let dataAm = [];
   try {
     Logger.error('Starting scraper idealist at', moment().format('LT'));
     [browser, page] = await startBrowser(headless);
@@ -125,6 +126,7 @@ async function main(headless) {
     await getElements(page).then((elements) => {
       getData(page, elements).then((data => {
         Logger.info(data);
+        dataAm = data;
         writeToJSON(data, 'idealist');
         browser.close();
       }));
@@ -133,7 +135,7 @@ async function main(headless) {
     await browser.close();
     Logger.warn('Idealist Error:', e);
   }
-  Logger.error(`Finished scraper idealist at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  Logger.error(`Elapsed time for idealist: ${moment(startTime).fromNow(true)} | ${dataAm.length} listings scraped `);
 }
 
 export default main;

--- a/scraper/scrapers/indeed.js
+++ b/scraper/scrapers/indeed.js
@@ -166,7 +166,7 @@ async function main(headless) {
     Logger.warn('Our Error:', e.message);
     await browser.close();
   }
-  Logger.error(`Finished scraper indeed at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  Logger.error(`Elapsed time for indeed: ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
 }
 
 export default main;

--- a/scraper/scrapers/internships.js
+++ b/scraper/scrapers/internships.js
@@ -38,6 +38,7 @@ async function main() {
     slowMo: 100,
   });
   const startTime = new Date();
+  const data = [];
   log.error('Starting scraper internships (chegg) at', moment().format('LT'));
   try {
     const page = await browser.newPage();
@@ -74,7 +75,6 @@ async function main() {
     await page.waitForSelector('div[class="GridItem_jobContent__ENwap"]');
     const target = await page.$$('div[class="GridItem_jobContent__ENwap"]');
     const totalJobs = target.length;
-    const data = [];
     let finishedJobs = 0;
     let skipped = 0;
     log.info('Starting scraping:');
@@ -169,7 +169,7 @@ async function main() {
     log.error('Our Error:', e.message);
     await browser.close();
   }
-  log.error(`Finished scraper internships (chegg) at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  log.error(`Elapsed time for internships (Chegg): ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
 }
 
 export default main;

--- a/scraper/scrapers/linkedin.js
+++ b/scraper/scrapers/linkedin.js
@@ -135,7 +135,7 @@ export async function main(headless) {
     Logger.debug('Our Error:', e.message);
     await browser.close();
   }
-  Logger.error(`Finished scraper linkedin at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  Logger.error(`Elapsed time for linkedin: ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
 }
 
 export default main;

--- a/scraper/scrapers/monster.js
+++ b/scraper/scrapers/monster.js
@@ -115,7 +115,7 @@ export async function main(headless) {
     Logger.debug('Our Error:', e.message);
     await browser.close();
   }
-  Logger.error(`Finished scraper monster at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  Logger.error(`Elapsed time for monster: ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
 }
 
 export default main;

--- a/scraper/scrapers/nsf-reu.js
+++ b/scraper/scrapers/nsf-reu.js
@@ -89,7 +89,7 @@ async function main() {
   } catch (err3) {
     log.error(err3.message);
   }
-  log.error(`Finished scraper nsf-reu at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  log.error(`Elapsed time for nsf-reu: ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
 }
 
 export default main;

--- a/scraper/scrapers/scraper-functions.js
+++ b/scraper/scrapers/scraper-functions.js
@@ -12,13 +12,13 @@ import Logger from 'loglevel';
  * @returns {Promise<*>} The information as a String.
  */
 async function fetchInfo(page, selector, DOM_Element) {
-  let result;
-  try {
-    await page.waitForSelector(selector, { timeout: 10000 });
-    result = await page.evaluate((select, element) => document.querySelector(select)[element], selector, DOM_Element);
-  } catch (error) {
-    Logger.error('Our Error: fetchInfo() failed.\n', error.message);
+  // check to see if the selector exists
+  let result = await page.$(selector);
+  if (result === null) {
     result = 'Error';
+    console.trace('\x1b[4m\x1b[33m%s\x1b[0m', `${selector} does not exist.`);
+  } else {
+    result = await page.evaluate((select, element) => document.querySelector(select)[element], selector, DOM_Element);
   }
   return result;
 }

--- a/scraper/scrapers/simplyHired.js
+++ b/scraper/scrapers/simplyHired.js
@@ -69,6 +69,7 @@ export async function main(headless) {
   let browser;
   let page;
   const startTime = new Date();
+  const data = [];
   try {
     Logger.error('Starting scraper simplyhired at', moment().format('LT'));
     [browser, page] = await startBrowser(headless, false, 100);
@@ -92,7 +93,6 @@ export async function main(headless) {
 
     let totalPages = 1;
     let totalJobs = 0;
-    const data = [];
 
     // check to see if internship tag exists
     if (internshipDropdown.length > 0) {
@@ -209,7 +209,7 @@ export async function main(headless) {
   } catch (e) {
     Logger.trace('Our Error: ', e.message);
   }
-  Logger.error(`Finished scraper simplyhired at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  Logger.error(`Elapsed time for simplyHired: ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
 }
 
 export default main;

--- a/scraper/scrapers/stackoverflow.js
+++ b/scraper/scrapers/stackoverflow.js
@@ -83,6 +83,7 @@ async function main(headless) {
   let browser;
   let page;
   const startTime = new Date();
+  let dataAm = [];
   try {
     Logger.error('Starting scraper stackoverflow at', moment().format('LT'));
     [browser, page] = await startBrowser(headless);
@@ -90,6 +91,7 @@ async function main(headless) {
     await page.waitForNavigation;
     // grab all links
     await getData(page).then((data => {
+      dataAm = data;
       Logger.info(data);
       writeToJSON(data, 'stackoverflow');
     }));
@@ -98,7 +100,7 @@ async function main(headless) {
     Logger.warn('Our Error:', err.message);
     await browser.close();
   }
-  Logger.error(`Finished scraper stackoverflow at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  Logger.error(`Elapsed time for stackoverflow: ${moment(startTime).fromNow(true)} | ${dataAm.length} listings scraped `);
 }
 
 export default main;

--- a/scraper/scrapers/studentOpportunityCenter.js
+++ b/scraper/scrapers/studentOpportunityCenter.js
@@ -102,7 +102,7 @@ export async function main(headless) {
   } catch (e) {
     Logger.trace('Our Error: ', e.message);
   }
-  Logger.error(`Finished scraper studentOpportunityCenter at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  Logger.error(`Elapsed time for studentOpportunityCenter: ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
 }
 
 export default main;

--- a/scraper/scrapers/zipRecruiter.js
+++ b/scraper/scrapers/zipRecruiter.js
@@ -130,7 +130,7 @@ async function main(headless) {
     Logger.warn('Our Error:', e.message);
     await browser.close();
   }
-  Logger.error(`Finished scraper zipRecruiter at ${moment().format('LT')} (${moment(startTime).fromNow()})`);
+  Logger.error(`Elapsed time for zipRecruiter: ${moment(startTime).fromNow(true)} | ${data.length} listings scraped `);
 }
 
 export default main;


### PR DESCRIPTION
Logs now look like:
```shell
> node scrapers/main.js "production"

Starting scraper apple at 11:55 AM
Starting scraper acm at 11:55 AM
Starting scraper aexpress at 11:55 AM
Starting scraper linkedin at 11:55 AM
Starting scraper monster at 11:55 AM
Starting scraper simplyhired at 11:55 AM
Starting scraper Cisco at 11:55 AM
Starting scraper zipRecruiter at 11:55 AM
Starting scraper stackoverflow at 11:55 AM
Starting scraper indeed at 11:55 AM
Starting scraper idealist at 11:55 AM
Starting scraper hawaiislack at 11:55 AM
Starting scraper Glassdoor at 11:55 AM
Starting scraper nsf-reu at 11:55 AM
Elapsed time for nsf-reu: a few seconds | 93 listings scraped
Elapsed time for hawaiislack: a few seconds | 0 listings scraped
Elapsed time for stackoverflow: a few seconds | 6 listings scraped
Elapsed time for idealist: a few seconds | 0 listings scraped
Elapsed time for simplyHired: a few seconds | 2 listings scraped
Elapsed time for aexpress: a few seconds | 8 listings scraped
Elapsed time for indeed: a few seconds | 2 listings scraped
Elapsed time for glassdoor: a few seconds | 0 listings scraped
Elapsed time for Cisco: a few seconds | 9 listings scraped
Elapsed time for zipRecruiter: a minute | 23 listings scraped
Elapsed time for linkedin: a minute | 7 listings scraped
Elapsed time for apple: 2 minutes | 40 listings scraped
Elapsed time for acm: 7 minutes | 156 listings scraped
Elapsed time for monster: an hour | 224 listings scraped
```